### PR TITLE
Cleanup SSL_CLIENT_CERT before saving it in $_SESSION

### DIFF
--- a/auth/index.php
+++ b/auth/index.php
@@ -15,7 +15,22 @@ require_once(DOKU_INC.'inc/pageutils.php');
 // if smartcard auth was success, write SSL_CLIENT_CERT to session (it will be used from auth_smartcard later on)
 if(isset($_SERVER['SSL_CLIENT_CERT'])){
   session_start();
-  $_SESSION['SSL_CLIENT_CERT']=$_SERVER['SSL_CLIENT_CERT'];
+  $cert = $_SERVER['SSL_CLIENT_CERT'];
+
+  // Strip BEGIN/END CERTIFICATE
+  $pattern = '/-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----/msU';
+  if (1 === preg_match($pattern, $cert, $matches)) {
+	  $cert = $matches[1];
+  }
+
+  // Create one long string of the certificate
+  $replaceCharacters = array(" ", "\t", "\n", "\r", "\0" , "\x0B");
+  $cert = str_replace($replaceCharacters, '', $cert);
+
+  // Wrap into lines and save
+  $wrapped = wordwrap($cert, 64, "\n", true);
+  $_SESSION['SSL_CLIENT_CERT'] = "-----BEGIN CERTIFICATE-----".PHP_EOL.$wrapped.PHP_EOL."-----END CERTIFICATE-----".PHP_EOL;
+
   session_write_close();
 }
 


### PR DESCRIPTION
Hi!

I'm using Dokuwiki behind reverse proxy. Unfortunately certificate is a little bit malformed when it's passed through HTTP headers (eg new lines are converted to spaces). I prepared a fix which makes sure that certificate is in proper format before saving it in `$_SESSION`.

Kind regards,
Patryk
